### PR TITLE
feat: add optional You.com search backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">Daedra</h1>
 
 <p align="center">
-  Self-contained web search MCP server. Rust. 16 backends. Works from any IP.<br>
+  Self-contained web search MCP server. Rust. 17 backends. Works from any IP.<br>
   Single binary. Relevance-ranked multi-backend search. Zero configuration for basic search.
 </p>
 
@@ -24,18 +24,18 @@ Daedra is a self-contained web search [MCP](https://modelcontextprotocol.io/) se
 Major search engines block datacenter and VPS IP addresses with CAPTCHAs. Daedra solves this with a multi-backend fan-out. All available backends run the query at once, and the results merge by relevance:
 
 ```
-Serper (API) → Tavily (API) → Mojeek → Brave → Bing RSS → Bing → Google News → Hacker News → Marginalia → Google → Wikipedia → StackOverflow → GitHub → Wiby → DDG Instant → DuckDuckGo HTML
+Serper (API) → Tavily (API) → You.com (API) → Mojeek → Brave → Bing RSS → Bing → Google News → Hacker News → Marginalia → Google → Wikipedia → StackOverflow → GitHub → Wiby → DDG Instant → DuckDuckGo HTML
 ```
 
 Three backend groups exist. API backends need a key. Scraper backends read HTML and sometimes meet a CAPTCHA. Machine-format backends read the RSS and JSON feeds that the engines publish for integrations. The machine-format backends work from any IP with no key.
 
-Unkeyed general coverage depends on where daedra runs. Marginalia answers from any IP. Mojeek and Brave serve residential IPs and refuse datacenter ones; the circuit breaker sidelines them there. The knowledge and machine-format backends (wiki, HN, StackOverflow, GitHub, Bing RSS, Google News) work from any IP. Set `SERPER_API_KEY` or `TAVILY_API_KEY` for general search quality on any network.
+Unkeyed general coverage depends on where daedra runs. Marginalia answers from any IP. Mojeek and Brave serve residential IPs and refuse datacenter ones; the circuit breaker sidelines them there. The knowledge and machine-format backends (wiki, HN, StackOverflow, GitHub, Bing RSS, Google News) work from any IP. Set `SERPER_API_KEY`, `TAVILY_API_KEY`, or `YDC_API_KEY` for general search quality on any network.
 
 Per-backend circuit breakers and per-backend rate limits keep the chain stable under load. The chain retries only transient errors. Bot protection and rate-limit errors fail fast, so the next backend starts at once.
 
 ## Features
 
-- 16 search backends with automatic fallback (see the table below)
+- 17 search backends with automatic fallback (see the table below)
 - Circuit breaker (`BackendHealth`): opens after repeated failures, with a 30 second cooldown
 - Per-backend rate limits via `governor`, with separate quotas for API, knowledge, and scraper backends
 - Classified retry: the chain retries only transient errors
@@ -57,6 +57,7 @@ cargo install daedra
 |---------|------|---------|----------------|
 | Serper.dev | Google JSON API | `SERPER_API_KEY` | Yes |
 | Tavily | AI-optimized API | `TAVILY_API_KEY` | Yes |
+| You.com | Unified web/news API | `YDC_API_KEY` | Yes |
 | **Bing RSS** | `format=rss` machine output | None | **Always** |
 | Bing | HTML scraping | None | Sometimes (CAPTCHA risk) |
 | **Google News** | News RSS feed | None | **Always** |
@@ -71,7 +72,7 @@ cargo install daedra
 
 The merge ranks every result by how much of the query it shares. Results that share no query token land after every matched result. When no result matches at all, the search reports this. It does not return unrelated feed noise. Backends that ignore the query cannot outvote backends that found nothing relevant.
 
-Without API keys the backends are the knowledge and feed sources (Wikipedia, Hacker News, StackOverflow, GitHub, RSS). This is a research slice of the web, not a general web search. Set `SERPER_API_KEY` or `TAVILY_API_KEY` for general search quality.
+Without API keys the backends are the knowledge and feed sources (Wikipedia, Hacker News, StackOverflow, GitHub, RSS). This is a research slice of the web, not a general web search. Set `SERPER_API_KEY`, `TAVILY_API_KEY`, or `YDC_API_KEY` for general search quality.
 
 `--backend` and `--exclude` select or skip backends by name. `--time-range d|w|m|y` filters by recency on the backends that support it (Serper, Tavily, Hacker News, Google News).
 
@@ -207,6 +208,7 @@ Daedra
 # Optional API keys (improve result quality)
 export SERPER_API_KEY=...     # Google results via Serper
 export TAVILY_API_KEY=...     # AI-optimized search
+export YDC_API_KEY=...        # Unified web/news search via You.com
 export GITHUB_TOKEN=...       # Higher GitHub API rate limit
 
 # Logging

--- a/src/server.rs
+++ b/src/server.rs
@@ -190,7 +190,7 @@ impl DaedraHandler {
             McpTool {
                 name: "web_search".to_string(),
                 description: Some(
-                    "Search the web across 14 backends (Mojeek, Brave, Marginalia, Bing RSS, Bing, Google News, Hacker News, Google, Wikipedia, StackOverflow, GitHub, Wiby, DDG Instant, DDG; plus Serper and Tavily with API keys). Results merge by relevance with cross-engine corroboration."
+                    "Search the web across 14 backends (Mojeek, Brave, Marginalia, Bing RSS, Bing, Google News, Hacker News, Google, Wikipedia, StackOverflow, GitHub, Wiby, DDG Instant, DDG; plus Serper, Tavily, and You.com with API keys). Results merge by relevance with cross-engine corroboration."
                         .to_string(),
                 ),
                 input_schema: search_args_schema(),
@@ -198,7 +198,7 @@ impl DaedraHandler {
             McpTool {
                 name: "search_duckduckgo".to_string(),
                 description: Some(
-                    "Alias for web_search (backward compatibility). Search the web across 14 backends (Mojeek, Brave, Marginalia, Bing RSS, Bing, Google News, Hacker News, Google, Wikipedia, StackOverflow, GitHub, Wiby, DDG Instant, DDG; plus Serper and Tavily with API keys). Results merge by relevance with cross-engine corroboration."
+                    "Alias for web_search (backward compatibility). Search the web across 14 backends (Mojeek, Brave, Marginalia, Bing RSS, Bing, Google News, Hacker News, Google, Wikipedia, StackOverflow, GitHub, Wiby, DDG Instant, DDG; plus Serper, Tavily, and You.com with API keys). Results merge by relevance with cross-engine corroboration."
                         .to_string(),
                 ),
                 input_schema: search_args_schema(),

--- a/src/tools/backend.rs
+++ b/src/tools/backend.rs
@@ -4,6 +4,7 @@
 //! - Bing HTML scraping (default, no API key needed)
 //! - Serper.dev (Google results via API, needs SERPER_API_KEY)
 //! - Tavily (AI-optimized search, needs TAVILY_API_KEY)
+//! - You.com (unified web/news search via API, needs YDC_API_KEY)
 //! - DuckDuckGo HTML scraping (blocked from datacenter IPs, fallback only)
 
 use crate::types::{DaedraError, DaedraResult, SearchArgs, SearchResponse};
@@ -213,6 +214,14 @@ impl SearchProvider {
         {
             info!("Tavily backend enabled (TAVILY_API_KEY set)");
             backends.push(Box::new(super::tavily::TavilyBackend::new(key)));
+        }
+
+        // You.com — unified web/news search via API, opt-in behind YDC_API_KEY.
+        if let Ok(key) = std::env::var("YDC_API_KEY")
+            && !key.is_empty()
+        {
+            info!("You.com backend enabled (YDC_API_KEY set)");
+            backends.push(Box::new(super::youcom::YouComBackend::new(key)));
         }
 
         // Mojeek — independent crawler index, no API key, bot-tolerant from

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -3,10 +3,11 @@
 //! Search backends (in fallback order):
 //! 1. Serper.dev — Google results via API (needs SERPER_API_KEY)
 //! 2. Tavily — AI-optimized search (needs TAVILY_API_KEY)
-//! 3. Bing HTML scraping — no key, but blocked from most datacenter IPs
-//! 4. Wikipedia — always works, knowledge-focused
-//! 5. StackExchange — always works, technical Q&A
-//! 6. DuckDuckGo — blocked from datacenter IPs, last resort
+//! 3. You.com — unified web/news search via API (needs YDC_API_KEY)
+//! 4. Bing HTML scraping — no key, but blocked from most datacenter IPs
+//! 5. Wikipedia — always works, knowledge-focused
+//! 6. StackExchange — always works, technical Q&A
+//! 7. DuckDuckGo — blocked from datacenter IPs, last resort
 
 pub mod backend;
 pub mod bing;
@@ -26,6 +27,7 @@ pub mod stackexchange;
 pub mod tavily;
 pub mod wiby;
 pub mod wikipedia;
+pub mod youcom;
 
 pub use backend::*;
 pub use crawl::{crawl_site, parse_sitemap};

--- a/src/tools/youcom.rs
+++ b/src/tools/youcom.rs
@@ -1,0 +1,340 @@
+//! You.com web search backend.
+//!
+//! Uses the You.com Web Search API to return unified web and news results.
+//! Requires `YDC_API_KEY` and stays opt-in through `SearchProvider::auto()`.
+
+use super::backend::SearchBackend;
+use crate::types::{
+    ContentType, DaedraError, DaedraResult, ResultMetadata, SearchArgs, SearchOptions,
+    SearchResponse, SearchResult, region_to_gl_hl,
+};
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::Deserialize;
+use std::time::Duration;
+use tracing::info;
+use url::Url;
+
+const YOUCOM_SEARCH_URL: &str = "https://ydc-index.io/v1/search";
+
+/// You.com Search API backend.
+pub struct YouComBackend {
+    client: Client,
+    api_key: String,
+    base_url: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct YouComResponse {
+    results: Option<YouComResults>,
+}
+
+#[derive(Debug, Deserialize)]
+struct YouComResults {
+    #[serde(default)]
+    web: Vec<YouComWebResult>,
+    #[serde(default)]
+    news: Vec<YouComNewsResult>,
+}
+
+#[derive(Debug, Deserialize)]
+struct YouComWebResult {
+    title: String,
+    url: String,
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    snippets: Vec<String>,
+    #[serde(default)]
+    thumbnail_url: Option<String>,
+    #[serde(default)]
+    favicon_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct YouComNewsResult {
+    title: String,
+    url: String,
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    thumbnail_url: Option<String>,
+    #[serde(default)]
+    page_age: Option<String>,
+}
+
+impl YouComBackend {
+    /// Create a new You.com backend instance.
+    pub fn new(api_key: String) -> Self {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .expect("HTTP client");
+        Self {
+            client,
+            api_key,
+            base_url: YOUCOM_SEARCH_URL.to_string(),
+        }
+    }
+
+    fn search_body(&self, args: &SearchArgs, opts: &SearchOptions) -> serde_json::Value {
+        let mut body = serde_json::json!({
+            "query": args.query,
+            "count": opts.num_results.clamp(1, 100),
+        });
+
+        if let Some(tr) = &opts.time_range {
+            let freshness = match tr.as_str() {
+                "d" => Some("day"),
+                "w" => Some("week"),
+                "m" => Some("month"),
+                "y" => Some("year"),
+                other if other.contains("to") => Some(other),
+                _ => None,
+            };
+            if let Some(freshness) = freshness {
+                body["freshness"] = serde_json::Value::String(freshness.to_string());
+            }
+        }
+
+        let (country, language) = region_to_gl_hl(&opts.region);
+        if let Some(country) = country {
+            body["country"] = serde_json::Value::String(country);
+        }
+        if let Some(language) = language {
+            body["language"] = serde_json::Value::String(language);
+        }
+
+        body["safesearch"] = serde_json::Value::String(
+            match opts.safe_search {
+                crate::types::SafeSearchLevel::Off => "off",
+                crate::types::SafeSearchLevel::Moderate => "moderate",
+                crate::types::SafeSearchLevel::Strict => "strict",
+            }
+            .to_string(),
+        );
+
+        body
+    }
+
+    fn map_results(&self, data: YouComResponse) -> Vec<SearchResult> {
+        let mut results = Vec::new();
+
+        if let Some(results_block) = data.results {
+            results.extend(
+                results_block
+                    .web
+                    .into_iter()
+                    .map(|item| self.web_result_to_search_result(item)),
+            );
+            results.extend(
+                results_block
+                    .news
+                    .into_iter()
+                    .map(|item| self.news_result_to_search_result(item)),
+            );
+        }
+
+        results
+    }
+
+    fn source_from_url(url: &str) -> String {
+        Url::parse(url)
+            .ok()
+            .and_then(|parsed| parsed.domain().map(str::to_string))
+            .unwrap_or_else(|| "you.com".to_string())
+    }
+
+    fn web_result_to_search_result(&self, item: YouComWebResult) -> SearchResult {
+        let description = if item.snippets.is_empty() {
+            item.description
+        } else {
+            item.snippets.join(" ")
+        };
+
+        SearchResult {
+            title: item.title,
+            url: item.url.clone(),
+            description,
+            metadata: ResultMetadata {
+                content_type: ContentType::Other,
+                source: Self::source_from_url(&item.url),
+                favicon: item.favicon_url.or(item.thumbnail_url),
+                published_date: None,
+            },
+        }
+    }
+
+    fn news_result_to_search_result(&self, item: YouComNewsResult) -> SearchResult {
+        SearchResult {
+            title: item.title,
+            url: item.url.clone(),
+            description: item.description,
+            metadata: ResultMetadata {
+                content_type: ContentType::Article,
+                source: Self::source_from_url(&item.url),
+                favicon: item.thumbnail_url,
+                published_date: item.page_age,
+            },
+        }
+    }
+}
+
+impl Default for YouComBackend {
+    fn default() -> Self {
+        Self::new(String::new())
+    }
+}
+
+#[async_trait]
+impl SearchBackend for YouComBackend {
+    async fn search(&self, args: &SearchArgs) -> DaedraResult<SearchResponse> {
+        let opts = args.options.clone().unwrap_or_default();
+        let body = self.search_body(args, &opts);
+
+        let resp = self
+            .client
+            .post(&self.base_url)
+            .header("X-API-Key", &self.api_key)
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(DaedraError::HttpError)?;
+
+        if !resp.status().is_success() {
+            return Err(DaedraError::SearchError(format!(
+                "You.com API returned {}",
+                resp.status()
+            )));
+        }
+
+        let data: YouComResponse = resp.json().await.map_err(DaedraError::HttpError)?;
+        let results = self.map_results(data);
+
+        info!(
+            backend = "youcom",
+            results = results.len(),
+            "You.com search complete"
+        );
+        Ok(SearchResponse::new(args.query.clone(), results, &opts))
+    }
+
+    fn name(&self) -> &str {
+        "youcom"
+    }
+
+    fn requires_api_key(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{body_json, header, method, path},
+    };
+
+    fn backend_for(server: &MockServer) -> YouComBackend {
+        YouComBackend {
+            client: Client::builder()
+                .timeout(Duration::from_secs(30))
+                .build()
+                .expect("HTTP client"),
+            api_key: "test-key".to_string(),
+            base_url: format!("{}/v1/search", server.uri()),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_youcom_search_maps_web_and_news_results() {
+        let server = MockServer::start().await;
+        let backend = backend_for(&server);
+
+        Mock::given(method("POST"))
+            .and(path("/v1/search"))
+            .and(header("X-API-Key", "test-key"))
+            .and(body_json(serde_json::json!({
+                "query": "rust async runtime",
+                "count": 3,
+                "freshness": "week",
+                "country": "us",
+                "language": "en",
+                "safesearch": "strict"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "results": {
+                    "web": [
+                        {
+                            "title": "Tokio tutorial",
+                            "url": "https://tokio.rs/",
+                            "description": "Tokio is an async runtime for Rust.",
+                            "snippets": ["Tokio is an async runtime for Rust."],
+                            "favicon_url": "https://tokio.rs/favicon.ico",
+                            "thumbnail_url": "https://tokio.rs/thumb.png"
+                        }
+                    ],
+                    "news": [
+                        {
+                            "title": "Rust async update",
+                            "url": "https://example.com/news/rust-async",
+                            "description": "A recent update about async Rust.",
+                            "thumbnail_url": "https://example.com/thumb.jpg",
+                            "page_age": "2026-08-28T12:00:00"
+                        }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let args = SearchArgs {
+            query: "rust async runtime".to_string(),
+            options: Some(SearchOptions {
+                region: "us-en".to_string(),
+                safe_search: crate::types::SafeSearchLevel::Strict,
+                num_results: 3,
+                time_range: Some("w".to_string()),
+                backends: None,
+                exclude_backends: None,
+            }),
+        };
+
+        let response = backend.search(&args).await.expect("search response");
+        assert_eq!(response.data.len(), 2);
+        assert_eq!(response.data[0].title, "Tokio tutorial");
+        assert_eq!(
+            response.data[0].metadata.favicon.as_deref(),
+            Some("https://tokio.rs/favicon.ico")
+        );
+        assert_eq!(response.data[0].metadata.source, "tokio.rs");
+        assert_eq!(response.data[1].metadata.content_type, ContentType::Article);
+        assert_eq!(
+            response.data[1].metadata.published_date.as_deref(),
+            Some("2026-08-28T12:00:00")
+        );
+        assert_eq!(response.metadata.search_context.safe_search, "STRICT");
+    }
+
+    #[tokio::test]
+    async fn test_youcom_search_errors_on_non_success_status() {
+        let server = MockServer::start().await;
+        let backend = backend_for(&server);
+
+        Mock::given(method("POST"))
+            .and(path("/v1/search"))
+            .respond_with(ResponseTemplate::new(403))
+            .mount(&server)
+            .await;
+
+        let args = SearchArgs {
+            query: "rust".to_string(),
+            options: Some(SearchOptions::default()),
+        };
+
+        let err = backend.search(&args).await.expect_err("expected error");
+        assert!(err.to_string().contains("You.com API returned 403"));
+    }
+}


### PR DESCRIPTION
This adds an optional You.com backend to the existing search fan-out. I kept it opt-in and followed the current backend pattern so the default search path does not change.

What changed:
- Added a `YouComBackend` that calls `POST https://ydc-index.io/v1/search` with `X-API-Key` auth.
- Mapped You.com web and news results into Daedra `SearchResult` values.
- Enabled the backend only when `YDC_API_KEY` is set.
- Updated the backend registry, MCP tool descriptions, and README docs.

Setup:
- Set `YDC_API_KEY`.
- No other configuration is required.

Usage example:
```bash
YDC_API_KEY=... daedra search "rust async runtime"
```

Fallback/error behavior:
- If `YDC_API_KEY` is absent, You.com is skipped and the rest of the search chain behaves as before.
- If You.com returns a non-success status, the backend returns a search error and other backends still participate normally.

Validation:
- `cargo fmt`
- `cargo +1.98.0 test youcom -- --nocapture`
- `cargo +1.98.0 test test_auto_has_backends -- --nocapture`
- `cargo +1.98.0 test test_list_tools -- --nocapture`

Tracking issue: https://github.com/youdotcom-oss/integration-tracking/issues/221